### PR TITLE
fix to allow spaces in file name/path

### DIFF
--- a/jenkins2git.sh
+++ b/jenkins2git.sh
@@ -7,7 +7,7 @@ ls -1d *.xml secrets/ jobs/*/*.xml nodes/*/*.xml userContent/* users/*/config.xm
     plugins/*/META-INF/MANIFEST.MF 2>/dev/null | grep -v '^queue.xml$' | xargs -r -d '\n' git add --
 
 # Track deleted files:
-LANG=C git status --porcelain | awk '$1 == "D" { print $2; }' | xargs -r git rm --ignore-unmatch
+LANG=C git status --porcelain | sed -r -e '/^ D /!d' -e 's/^ D //1' | xargs -r git rm --ignore-unmatch
 
 LANG=C git status | grep -q '^nothing to commit' || {
     git commit -m "Automated Jenkins commit at $(date '+%Y-%m-%d %H:%M')"


### PR DESCRIPTION
If you have spaces in file names or in path, the current implementation will fail because of `awk '$1 == "D" { print $2; }'` that will extract only the first part of the file path, up to the first space.
The fixes implements a way to circumvent this using `sed`